### PR TITLE
fix(invoice): mock Alegra invoice creation (free-plan workaround)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,12 @@
 VITE_ALEGRA_API_KEY=
 VITE_ALEGRA_BASE_URL=https://api.alegra.com/api/v1/
 
+# This project runs on Alegra's free/trial plan, which does not include
+# POST /invoices. Invoice creation is mocked client-side by default
+# (SPEC-P4-09) so the contest flow never dead-ends on a plan error.
+# Set to false only if the Alegra plan is upgraded to one that includes
+# the invoices endpoint.
+VITE_ALEGRA_MOCK_INVOICES=true
+
 # Unsplash API (rotate the previous key - it was exposed in source code)
 VITE_UNSPLASH_ACCESS_KEY=

--- a/CHANGELOG-PROPOSALS.md
+++ b/CHANGELOG-PROPOSALS.md
@@ -588,6 +588,36 @@ PENDING (awaiting Jör approval via PR)
 
 ---
 
+## PROPOSAL-2026-023: Mock Alegra Invoice Creation (Free-Plan Workaround)
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-09-04 |
+| **Branch** | `fix/mock-invoice-creation` |
+| **Spec** | SPEC-P4-09 |
+| **Estimate** | 2h |
+| **Submitted By** | Broker |
+
+### Description
+The Alegra account behind this project is a free/trial plan with no access to `POST /invoices`, so every invoice submission at the end of the contest flow failed with an auth/plan error and the flow dead-ended (no success handling existed either way — a pre-existing ADS gap). Jör confirmed the plan will never be upgraded (portfolio/practice project), so the fix is to stop calling that endpoint and simulate success client-side:
+- `src/utils/generateMockInvoice.ts` (new) — pure function building a fake `InvoiceResponse` (id + human-readable invoice number) from the form payload
+- `src/services/apiService.ts` — `createInvoice()` returns the mock invoice instead of calling `axiosClient`, gated by `VITE_ALEGRA_MOCK_INVOICES` (default `true`); `GET /sellers` untouched
+- `src/components/InvoiceSuccessModal.vue` (new) — confirmation popup (number, date, total, "back to home"), mirrors `WinnerModal.vue`'s existing modal pattern
+- `src/composables/useInvoices.ts` — `submit()` now returns the created invoice so the view can display it
+- `src/stores/invoices/types/index.ts` — `InvoiceResponse` gains `number: string`
+- `.env.example` / `.env` — documented `VITE_ALEGRA_MOCK_INVOICES` flag (flip to `false` if the plan is ever upgraded)
+- `src/i18n/{es,en,de}.json` — new `invoice.success*` strings
+- No mock invoice is persisted anywhere (no localStorage, no backend) — by Jör's explicit decision
+- New unit tests: `generateMockInvoice.spec.ts`, `apiService.spec.ts`
+
+### Status
+IMPLEMENTED locally on `fix/mock-invoice-creation` — `npm run lint` and `npm run type-check` verified green in this session; `npm run test:unit` and `npm run build` could not be run in this session (sandboxed device shell blocked `@rolldown/binding-linux-x64-gnu` with a 403 at the network layer — unrelated to this change, reproducible on `staging` before any of these edits). **Awaiting Jör to run `npm run test:unit` and `npm run build` locally to confirm**, then push/PR.
+
+### Approval
+- **Jör Approved:** 2026-09-04, in chat ("do it")
+
+---
+
 <!--
 Template for new proposals - to be copied when Broker submits:
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -149,6 +149,35 @@ W2 contains two platform migrations approved separately: ADR-001 (Vuex → Pinia
 - Two sequential reviews instead of one big one (slower wall-clock, better review quality).
 - On the Pinia PR, `jest.config.js` and build tooling must NOT be touched (enforced by SPEC-P2-01 out-of-scope).
 
+---
+
+### ADR-004: Mock Alegra invoice creation instead of calling the real endpoint
+
+**Status:** ACCEPTED
+
+### Context
+The Alegra account behind this project is a free/trial plan. `POST /invoices` is not available on that plan, so every invoice submission at the end of the contest flow fails with an auth/plan error, and the flow dead-ends (there was also no success UI even in a hypothetical working case — a separate pre-existing gap). Jör confirmed this project will remain on the free plan indefinitely (portfolio/practice use, not a paying account), so the endpoint will never succeed as-is.
+
+### Decision
+Stop calling `POST /invoices`. `apiService.createInvoice()` generates a realistic-looking fake invoice (id + formatted number) client-side and returns it in the same shape as a real response. A new `InvoiceSuccessModal.vue` confirms it to the user. The behavior is gated by `VITE_ALEGRA_MOCK_INVOICES` (default `true`) so the real call is one env-var flip away if the plan is ever upgraded. No mock invoice is persisted anywhere.
+
+### Options Considered
+1. **Hard mock, no toggle** - Simplest; always fabricate success. No path back to the real endpoint without a code change.
+2. **Env-gated mock** (CHOSEN) - Same UX today; flipping `VITE_ALEGRA_MOCK_INVOICES=false` restores the real call with no other code change, at effectively zero extra cost.
+3. **Honest fallback (no mock)** - Catch the plan error and tell the user invoicing isn't available on this plan, without implying success. Most transparent, but doesn't give the "it works" feeling Jör wants for a portfolio demo.
+4. **Upgrade the Alegra plan** - Removes the problem at the root, but is a recurring cost Jör has ruled out; not a code decision.
+
+### Rationale
+Jör chose the mock approach (option 2, effectively option 1 with a free toggle added) explicitly because this project will never be a paying Alegra account: "I won't ever pay [for the] pro plan, it's just for my portfolio and practicing." The env flag costs nothing extra to add and keeps a clean exit path if that ever changes.
+
+### Consequences
+- A real client would see a "success" confirmation for an invoice that does not exist in Alegra. Accepted: this is a demo/practice app, not a live billing system, and Jör was told this trade-off directly before approving.
+- `GET /sellers` is unaffected — that endpoint already works on the free plan.
+- Any future work that needs a *real* invoice again only requires flipping the existing env flag — no re-implementation.
+
+### Decided By
+Jör, 2026-09-04 (approved in chat: "do it")
+
 <!--
 Template for new ADRs - to be copied by Broker:
 

--- a/specs/SPEC-P4-09-mock-invoice-creation.md
+++ b/specs/SPEC-P4-09-mock-invoice-creation.md
@@ -1,0 +1,127 @@
+# SPEC-P4-09: Mock Alegra Invoice Creation (Free-Plan Workaround)
+
+| Field | Value |
+|-------|-------|
+| **Status** | IMPLEMENTED locally (lint + type-check verified; test/build pending Jör's local run — see §7) |
+| **Topic** | Alegra's free/trial plan does not include access to `POST /invoices`, so the last step of the contest flow (winner → invoice) fails with an auth/plan error. Stop calling that endpoint and simulate a successful invoice client-side instead, with a confirmation popup. |
+| **Estimate** | 2h (mock generator + service branch 0.5h, success modal + wiring 0.75h, i18n 0.25h, tests + docs 0.5h) |
+| **Branch** | `fix/mock-invoice-creation` |
+| **Proposal** | PROPOSAL-2026-023 |
+| **ADS Reference** | Section on `InvoiceForm.vue` findings: "No success handling" (pre-existing gap, line ~607) — no prior ADS section anticipated the Alegra plan limitation; this is a newly discovered operational constraint, not a documented risk. |
+
+## 1. Context
+
+Once a winner is chosen, the app routes the user to `InvoiceForm.vue`. On submit, `useInvoices().submit()` → `invoicesStore.handleCreateInvoice()` → `apiService.createInvoice()` sends a real `POST /invoices` to Alegra with the account's API key.
+
+The Alegra account behind this project is a free/trial plan, and that plan does not include the invoices endpoint. Every submission comes back as an auth/plan error, which the shared axios interceptor (`SPEC-P4-01`) correctly surfaces as a toast — but the flow simply dead-ends there. Jör has confirmed this project will stay on the free plan indefinitely (it's a portfolio/practice app, not a paying account), so this is not a transient bug to retry — the endpoint will never succeed under the current plan.
+
+Separately, the ADS already flagged that `InvoiceForm.vue` has **no success handling at all** — even a hypothetical successful Alegra response produces no confirmation UI today. Both problems are fixed together here since they're the same user-facing moment (submit → some kind of outcome).
+
+## 2. Topic & Scope
+
+- **Topic:** stop calling the unavailable Alegra `/invoices` endpoint; simulate a successful invoice locally and confirm it to the user with a popup.
+
+**In scope:**
+- `src/services/apiService.ts` — `createInvoice()` returns a locally generated invoice instead of calling `axiosClient` when mocking is enabled.
+- `src/utils/generateMockInvoice.ts` (new) — pure function that builds a fake `InvoiceResponse` (id + human-readable invoice number) from the form payload.
+- `src/stores/invoices/types/index.ts` — `InvoiceResponse` gains a `number: string` field (the display-friendly invoice number).
+- `src/composables/useInvoices.ts` — `submit()` returns the created invoice (or `null` on failure) so the view can show it.
+- `src/components/InvoiceSuccessModal.vue` (new) — confirmation popup: invoice number, date, total; a "back to home" action.
+- `src/views/InvoiceForm.vue` — show the modal on success; route back to `LandingPage` when the user continues.
+- `src/config/index.ts` — `ALEGRA.MOCK_INVOICE_PREFIX` constant (no magic strings).
+- `.env.example` / `.env` — `VITE_ALEGRA_MOCK_INVOICES` (defaults to `true`; set to `false` to restore the real Alegra call, e.g. if the plan is ever upgraded).
+- `src/i18n/{es,en,de}.json` — new `invoice.success*` strings.
+
+**Explicitly out of scope (forbidden in this branch):**
+- Persisting mock invoices anywhere (no localStorage log, no backend) — the popup is the only record, by Jör's decision.
+- Touching `GET /sellers` — that endpoint works today on the free plan and is untouched.
+- Any other Alegra endpoint, auth flow, or the axios client/interceptor itself (`SPEC-P4-01` stays as-is).
+- Redesigning the invoice form fields or validation.
+- Re-adding a real invoice path — that only happens if/when the plan changes, via the existing env flag, not in this branch.
+
+## 3. Design in plain words
+
+Right now, clicking "create invoice" sends a real request to an outside service (Alegra) that this project's free account isn't allowed to use, so it always comes back as an error — the user just sees a failure message and nothing else happens.
+
+Instead of asking that outside service for an invoice, the app now makes up a realistic-looking one itself: a made-up invoice number, today's date, and the total from the form. Nothing leaves the browser. The user then sees a clear "your invoice was created" popup with those details, and a button to go back to the start — the same feeling of success as if a real invoice had been created, without depending on a plan feature this account will never have.
+
+This is controlled by a single on/off switch (an environment variable). If the Alegra plan is ever upgraded, flipping that one switch is enough to make the app call the real endpoint again — nothing else has to change.
+
+## 4. The five design principles, in plain words
+
+- **S — one job each.** `generateMockInvoice.ts` only builds a fake invoice; `apiService` only decides mock-vs-real and shapes the endpoint call; `InvoiceSuccessModal.vue` only displays the result. None of them do each other's job.
+- **O — easy to extend.** Turning mocking off is a single environment variable, not a code change. Adding a real invoice-detail field later (e.g. a tax breakdown) means extending the generator, not rewriting the flow.
+- **L — interchangeable.** Whether `createInvoice()` runs the mock path or the real Alegra call, it returns the same `InvoiceResponse` shape — nothing downstream (the store, the modal) needs to know which one ran.
+- **I — minimal surface.** The modal only receives the three fields it displays (number, date, total) — not the whole payload or store internals.
+- **D — one source of truth.** The mock/real switch and the invoice-number format both live in one place (`.env` and `config/index.ts`), not scattered across files.
+
+## 4b. Technical patterns
+
+- **Strategy-by-flag** — `apiService.createInvoice()` picks between two interchangeable implementations (mock vs. real HTTP call) behind one boolean, without the caller knowing which ran.
+- **Pure function** — `generateMockInvoice()` takes inputs, returns a value, touches nothing external; trivially unit-testable and safe to call from anywhere.
+- **Modal pattern** (already established by `WinnerModal.vue`) — `InvoiceSuccessModal.vue` reuses the same `alegra-modal` / `alegra-modal-content` structure and `role="dialog"` accessibility markup, so this introduces no new modal pattern.
+
+## 5. Where things live and why
+
+```
+src/utils/generateMockInvoice.ts     ← NEW: pure fake-invoice builder (id, number)
+src/services/apiService.ts           ← createInvoice(): mock branch guarded by env flag
+src/stores/invoices/types/index.ts   ← InvoiceResponse gains `number: string`
+src/composables/useInvoices.ts       ← submit() now returns the created invoice (or null)
+src/components/InvoiceSuccessModal.vue ← NEW: confirmation popup (mirrors WinnerModal.vue)
+src/views/InvoiceForm.vue            ← shows the modal on success, routes home on continue
+src/config/index.ts                  ← ALEGRA.MOCK_INVOICE_PREFIX (no magic strings)
+.env.example                          ← VITE_ALEGRA_MOCK_INVOICES=true (documented)
+src/i18n/{es,en,de}.json             ← invoice.success* strings
+```
+
+Why here: this follows the same layering already used for the axios/error work (`SPEC-P4-01`) — services stay the only place that knows about HTTP vs. not, config stays the only place with tunable constants, and the modal reuses `WinnerModal.vue`'s established shape rather than inventing a new one.
+
+## 6. Rules going forward
+
+- [ ] The real Alegra `/invoices` call is never deleted — only bypassed behind `VITE_ALEGRA_MOCK_INVOICES`. Removing the real path entirely requires its own proposal.
+- [ ] No mock invoice is ever persisted (no localStorage, no backend write) unless a future proposal explicitly asks for it.
+- [ ] Any new visible string for the success popup goes into all three locale files — no hardcoded UI text.
+- [ ] `InvoiceResponse`'s shape stays identical whether it came from the mock or the real endpoint — callers must never branch on which one ran.
+
+## 7. Acceptance Criteria
+
+- [x] Submitting the invoice form never calls Alegra's `/invoices` endpoint while `VITE_ALEGRA_MOCK_INVOICES=true` (default) — covered by `apiService.spec.ts`
+- [x] `GET /sellers` still calls the real Alegra endpoint, unchanged — covered by `apiService.spec.ts`
+- [x] On submit, a popup appears showing a generated invoice number, the date, and the total — `InvoiceSuccessModal.vue` wired into `InvoiceForm.vue`
+- [x] "Back to home" on the popup returns the user to `LandingPage` — `handleSuccessContinue` in `InvoiceForm.vue`
+- [ ] Setting `VITE_ALEGRA_MOCK_INVOICES=false` restores the real `POST /invoices` call — not yet manually verified
+- [x] `npm run lint` exits 0 (verified in this session)
+- [x] `npm run type-check` exits 0 (verified in this session)
+- [ ] `npm run test:unit` exits 0 — **could not be verified in this session**: the sandboxed device shell used to run these commands hit a 403 from a network proxy fetching `@rolldown/binding-linux-x64-gnu` (a native dependency of `vitest`/`vite` 8), reproducible on a clean `staging` checkout before any of these changes — not caused by this branch. Needs a run in Jör's own terminal.
+- [ ] `npm run build` exits 0 — same blocker as above, unverified in this session
+- [x] Touched files: `src/utils/generateMockInvoice.ts`, `src/services/apiService.ts`, `src/stores/invoices/types/index.ts`, `src/composables/useInvoices.ts`, `src/components/InvoiceSuccessModal.vue`, `src/views/InvoiceForm.vue`, `src/config/index.ts`, `.env.example`, `.env`, `src/i18n/{es,en,de}.json`, `tests/unit/utils/generateMockInvoice.spec.ts`, `tests/unit/services/apiService.spec.ts`, `specs/SPEC-P4-09-*.md`, `CHANGELOG-PROPOSALS.md`, `DECISIONS.md`
+
+## 8. Risks & Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| A real client believes a genuine Alegra invoice was issued | Medium | Medium | Accepted by Jör: this is a portfolio/practice project on a free plan that will never be upgraded, not a live billing system |
+| Someone flips `VITE_ALEGRA_MOCK_INVOICES=false` without an active paid plan and reintroduces the original error | Low | Low | Documented in `.env.example`; default stays `true` |
+| Generated invoice number collides or looks fake to a reviewer | Low | Low | Number derives from a timestamp, unique per submission, formatted like a real invoice ID |
+| Modal styling diverges from `WinnerModal.vue` | Low | Low | Reuses the same `alegra-modal` SCSS mixin and dialog markup |
+
+## 9. Testing Strategy
+
+- `npm run lint`, `npm run type-check`, `npm run test:unit`, `npm run build`
+- New unit test: `generateMockInvoice()` returns a stable shape for a given payload/timestamp
+- New unit test: `apiService.createInvoice()` does not call `axiosClient` when mocking is enabled
+- Manual: submit the invoice form in `npm run dev`, confirm the popup appears with a number/date/total and "back to home" navigates correctly
+
+## 10. Estimate & Dependencies
+
+- **Estimate:** 2h (generator + service branch 0.5h, modal + wiring 0.75h, i18n 0.25h, tests + docs 0.5h)
+- **Dependencies:** builds on the axios/error-handling layer from `SPEC-P4-01` (already merged); no other upstream dependency
+- **Branch:** `fix/mock-invoice-creation`
+
+---
+
+## Approval
+
+- **Jör Approved:** 2026-09-04, in chat ("do it")
+- **Status:** IMPLEMENTED locally on `fix/mock-invoice-creation`, pending Jör's local `test:unit`/`build` verification and push/PR (see §7)

--- a/src/components/InvoiceSuccessModal.vue
+++ b/src/components/InvoiceSuccessModal.vue
@@ -1,0 +1,42 @@
+<!-- InvoiceSuccessModal.vue -->
+<template>
+  <div
+    v-if="show"
+    class="alegra-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="invoiceSuccessModalTitle"
+  >
+    <div class="alegra-modal-content">
+      <h2 id="invoiceSuccessModalTitle">{{ $t("invoice.successTitle") }}</h2>
+      <p>{{ $t("invoice.successMessage", { number: invoiceNumber }) }}</p>
+      <p>
+        <strong>{{ $t("invoice.successNumber") }}</strong> {{ invoiceNumber }}
+      </p>
+      <p>
+        <strong>{{ $t("invoice.successDate") }}</strong> {{ date }}
+      </p>
+      <p>
+        <strong>{{ $t("invoice.successTotal") }}</strong> {{ total }}
+      </p>
+      <button class="btn btn-primary mt-3" @click="proceed">
+        {{ $t("invoice.successContinue") }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  show: boolean;
+  invoiceNumber: string;
+  date: string;
+  total: number;
+}>();
+
+const emit = defineEmits<{
+  (e: "proceed"): void;
+}>();
+
+const proceed = () => emit("proceed");
+</script>

--- a/src/composables/useInvoices.ts
+++ b/src/composables/useInvoices.ts
@@ -1,5 +1,5 @@
 import { useInvoicesStore } from "@/stores/invoicesStore";
-import { InvoicePayload } from "@/stores/invoices/types";
+import { InvoicePayload, InvoiceResponse } from "@/stores/invoices/types";
 import getErrorMessage from "@/utils/getErrorMessage";
 import { useLoading } from "./useLoading";
 import { useError } from "./useError";
@@ -10,12 +10,15 @@ export function useInvoices() {
   const loading = useLoading(store);
   const error = useError(store);
 
-  const submit = async (payload: InvoicePayload) => {
+  const submit = async (
+    payload: InvoicePayload
+  ): Promise<InvoiceResponse | null> => {
     store.setLoading(true);
     try {
-      await store.handleCreateInvoice(payload);
+      return await store.handleCreateInvoice(payload);
     } catch (err) {
       store.setFailure(getErrorMessage(err, "Error creating an Invoice"));
+      return null;
     } finally {
       store.setLoading(false);
     }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -16,3 +16,7 @@ export const API = {
 export const IMAGES = {
   FALLBACK_URL: "https://via.placeholder.com/400x400?text=Sin+imagen",
 } as const;
+
+export const ALEGRA = {
+  MOCK_INVOICE_PREFIX: "INV",
+} as const;

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -34,7 +34,13 @@
     "productId": "Produkt-ID:",
     "total": "Gesamt:",
     "submit": "Rechnung erstellen",
-    "allFieldsRequired": "Alle Felder sind erforderlich!"
+    "allFieldsRequired": "Alle Felder sind erforderlich!",
+    "successTitle": "Rechnung erstellt!",
+    "successMessage": "Ihre Rechnung {number} wurde erstellt.",
+    "successNumber": "Rechnungsnummer:",
+    "successDate": "Datum:",
+    "successTotal": "Gesamt:",
+    "successContinue": "Zurück zur Startseite"
   },
   "winner": {
     "title": "Glückwunsch!",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -34,7 +34,13 @@
     "productId": "Product Id:",
     "total": "Total:",
     "submit": "Create invoice",
-    "allFieldsRequired": "All fields are required!"
+    "allFieldsRequired": "All fields are required!",
+    "successTitle": "Invoice created!",
+    "successMessage": "Your invoice {number} has been generated.",
+    "successNumber": "Invoice number:",
+    "successDate": "Date:",
+    "successTotal": "Total:",
+    "successContinue": "Back to home"
   },
   "winner": {
     "title": "Congratulations!",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -34,7 +34,13 @@
     "productId": "Id Producto:",
     "total": "Total:",
     "submit": "Crear factura",
-    "allFieldsRequired": "Todos los campos son necesarios!"
+    "allFieldsRequired": "Todos los campos son necesarios!",
+    "successTitle": "¡Factura creada!",
+    "successMessage": "Tu factura {number} ha sido generada.",
+    "successNumber": "Número de factura:",
+    "successDate": "Fecha:",
+    "successTotal": "Total:",
+    "successContinue": "Volver al inicio"
   },
   "winner": {
     "title": "Felicitationes!",

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -1,6 +1,15 @@
 import { InvoicePayload, InvoiceResponse } from "@/stores/invoices/types";
 import { Seller } from "@/stores/sellers/types";
 import axiosClient from "./axiosClient";
+import generateMockInvoice from "@/utils/generateMockInvoice";
+
+// The Alegra account behind this project is a free/trial plan and does not
+// have access to POST /invoices. Rather than let every submission fail,
+// invoice creation is mocked client-side by default (SPEC-P4-09). Setting
+// VITE_ALEGRA_MOCK_INVOICES=false restores the real Alegra call, e.g. if
+// the plan is ever upgraded.
+const MOCK_INVOICES =
+  (import.meta.env.VITE_ALEGRA_MOCK_INVOICES ?? "true") !== "false";
 
 const apiService = {
   async getSellers(): Promise<Seller[]> {
@@ -8,6 +17,9 @@ const apiService = {
     return response.data;
   },
   async createInvoice(payload: InvoicePayload): Promise<InvoiceResponse> {
+    if (MOCK_INVOICES) {
+      return generateMockInvoice(payload);
+    }
     const response = await axiosClient.post<InvoiceResponse>(
       "/invoices",
       payload

--- a/src/stores/invoices/types/index.ts
+++ b/src/stores/invoices/types/index.ts
@@ -15,4 +15,5 @@ export interface InvoicePayload {
 
 export interface InvoiceResponse {
   id: number;
+  number: string;
 }

--- a/src/utils/generateMockInvoice.ts
+++ b/src/utils/generateMockInvoice.ts
@@ -1,0 +1,23 @@
+import { ALEGRA } from "@/config";
+import { InvoicePayload, InvoiceResponse } from "@/stores/invoices/types";
+
+/**
+ * Builds a fake, realistic-looking InvoiceResponse without calling Alegra.
+ * Pure function: same inputs -> same shape (id is timestamp-derived, so it
+ * is only "stable" in the sense of always being a positive integer with a
+ * matching human-readable `number`).
+ */
+export default function generateMockInvoice(
+  payload: InvoicePayload,
+  now: number = Date.now()
+): InvoiceResponse {
+  const year = payload.date
+    ? new Date(payload.date).getFullYear()
+    : new Date(now).getFullYear();
+  const sequence = String(now).padStart(5, "0").slice(-5);
+
+  return {
+    id: now,
+    number: `${ALEGRA.MOCK_INVOICE_PREFIX}-${String(year)}-${sequence}`,
+  };
+}

--- a/src/views/InvoiceForm.vue
+++ b/src/views/InvoiceForm.vue
@@ -36,20 +36,32 @@
         </button>
       </form>
     </article>
+    <InvoiceSuccessModal
+      :show="showSuccessModal"
+      :invoice-number="invoiceResult?.number ?? ''"
+      :date="formData.date"
+      :total="formData.total"
+      @proceed="handleSuccessContinue"
+    />
   </article>
 </template>
 
 <script setup lang="ts">
-import { reactive } from "vue";
-import { useRoute } from "vue-router";
+import { reactive, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
-import { InvoicePayload } from "@/stores/invoices/types";
+import { InvoicePayload, InvoiceResponse } from "@/stores/invoices/types";
 import toastService from "@/utils/toastService";
 import { useInvoices } from "@/composables/useInvoices";
+import InvoiceSuccessModal from "@/components/InvoiceSuccessModal.vue";
 
 const { t } = useI18n();
 const route = useRoute();
+const router = useRouter();
 const { submit } = useInvoices();
+
+const showSuccessModal = ref(false);
+const invoiceResult = ref<InvoiceResponse | null>(null);
 
 const formData: InvoicePayload = reactive({
   date: "",
@@ -74,10 +86,19 @@ const validateFormData = () => {
 
 const handleSubmitFormData = async () => {
   if (validateFormData()) {
-    await submit(formData);
+    const result = await submit(formData);
+    if (result) {
+      invoiceResult.value = result;
+      showSuccessModal.value = true;
+    }
   } else {
     toastService.showWarn(t("invoice.allFieldsRequired"));
   }
+};
+
+const handleSuccessContinue = () => {
+  showSuccessModal.value = false;
+  router.push({ name: "LandingPage" });
 };
 </script>
 

--- a/tests/unit/services/apiService.spec.ts
+++ b/tests/unit/services/apiService.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const axiosMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock("@/services/axiosClient", () => ({
+  default: axiosMocks,
+}));
+
+import apiService from "@/services/apiService";
+import { InvoicePayload } from "@/stores/invoices/types";
+
+const payload: InvoicePayload = {
+  date: "2026-09-04",
+  dueDate: "2026-09-11",
+  client: 1,
+  winnerId: 1,
+  productId: 1,
+  total: 100,
+};
+
+describe("apiService.createInvoice", () => {
+  beforeEach(() => {
+    axiosMocks.get.mockReset();
+    axiosMocks.post.mockReset();
+  });
+
+  it("does not call axiosClient when mocking is enabled (default)", async () => {
+    const result = await apiService.createInvoice(payload);
+
+    expect(axiosMocks.post).not.toHaveBeenCalled();
+    expect(result.id).toBeTypeOf("number");
+    expect(result.number).toMatch(/^INV-\d{4}-\d{5}$/);
+  });
+
+  it("still calls the real endpoint for getSellers", async () => {
+    axiosMocks.get.mockResolvedValue({ data: [] });
+
+    await apiService.getSellers();
+
+    expect(axiosMocks.get).toHaveBeenCalledWith("/sellers");
+  });
+});

--- a/tests/unit/utils/generateMockInvoice.spec.ts
+++ b/tests/unit/utils/generateMockInvoice.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import generateMockInvoice from "@/utils/generateMockInvoice";
+import { InvoicePayload } from "@/stores/invoices/types";
+
+const payload: InvoicePayload = {
+  date: "2026-09-04",
+  dueDate: "2026-09-11",
+  client: 1,
+  winnerId: 1,
+  productId: 1,
+  total: 100,
+};
+
+describe("generateMockInvoice", () => {
+  it("builds an invoice number derived from the payload year and a fixed timestamp", () => {
+    const result = generateMockInvoice(payload, 1700000012345);
+
+    expect(result.id).toBe(1700000012345);
+    expect(result.number).toBe("INV-2026-12345");
+  });
+
+  it("falls back to the current year when the payload has no date", () => {
+    const noDatePayload: InvoicePayload = { ...payload, date: "" };
+    const result = generateMockInvoice(noDatePayload, 1700000000000);
+
+    expect(result.number).toMatch(/^INV-\d{4}-00000$/);
+  });
+
+  it("always returns a positive integer id and a matching number suffix", () => {
+    const result = generateMockInvoice(payload, 42);
+
+    expect(result.id).toBe(42);
+    expect(result.number.endsWith("00042")).toBe(true);
+  });
+});


### PR DESCRIPTION
The Alegra free/trial plan does not include POST /invoices, so the last step of the contest flow (winner -> invoice) always failed with an auth/plan error and had no success handling even in theory.

Per Jor's decision (this project stays on the free plan indefinitely), apiService.createInvoice() now generates a realistic mock invoice client-side instead of calling Alegra, gated by
VITE_ALEGRA_MOCK_INVOICES (default true). A new InvoiceSuccessModal confirms the invoice number/date/total and routes back to the landing page. GET /sellers is untouched.

Bugfix discovered live, not in the original estimation phases. SPEC-P4-09, PROPOSAL-2026-023, ADR-004.

lint + type-check verified green in this session; test:unit/build could not run here (sandboxed device shell blocked @rolldown/binding-linux-x64-gnu with a 403 at the network layer, reproducible on staging before this change) - needs a local run to confirm before merge.